### PR TITLE
Add `VERSION` to prevent warning on new install

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,3 +1,5 @@
+VERSION 0.6
+
 FROM busybox:1.32.0
 
 hello:


### PR DESCRIPTION
Right now, new installation tests using this repo (as directed on https://earthly.dev/get-earthly) print a warning. This should make it go away.